### PR TITLE
Fixes module naming in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module isal
+module github.com/intel/ISALgo
 
 go 1.20


### PR DESCRIPTION
This change is needed so that it is importable.